### PR TITLE
New transformer: string trim

### DIFF
--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -7,14 +7,13 @@ from thebeast.contrib.ftm_ext.rigged_entity_proxy import StrProxy
 
 # TODO: split into dates/names/others files
 
-def trim_string_arg(value: str, strip: str) -> str:
-    return value.strip(strip);
 
-def trim_string(values: List[StrProxy], strip=' ' ) -> List[StrProxy]:
+def trim_string(values: List[StrProxy], strip=" ") -> List[StrProxy]:
     """
     Strip garbage from string argument
     """
-    return [value.inject_meta_to_str(trim_string_arg(value, strip)) for value in values]
+    return [value.inject_meta_to_str(value.strip(strip)) for value in values]
+
 
 def mixed_charset_fixer(values: List[StrProxy]) -> List[StrProxy]:
     """

--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -7,6 +7,14 @@ from thebeast.contrib.ftm_ext.rigged_entity_proxy import StrProxy
 
 # TODO: split into dates/names/others files
 
+def trim_string_arg(value: str, strip: str) -> str:
+    return value.strip(strip);
+
+def trim_string(values: List[StrProxy], strip=' ' ) -> List[StrProxy]:
+    """
+    Strip garbage from string argument
+    """
+    return [value.inject_meta_to_str(trim_string_arg(value, strip)) for value in values]
 
 def mixed_charset_fixer(values: List[StrProxy]) -> List[StrProxy]:
     """


### PR DESCRIPTION
I needed this, so I made this.

Usage:
```yaml
              transformer:
                name: thebeast.contrib.transformers.trim_string
                params: 
                  strip: ' ,.' # chars to strip, space by default
```