### PR TITLE
Fix output uri for sample mappings

### DIFF
--- a/thebeast/tests/sample/mappings/ukrainian_mps.yaml
+++ b/thebeast/tests/sample/mappings/ukrainian_mps.yaml
@@ -165,4 +165,4 @@ dump:
   cls: thebeast.dump.FTMLinesWriter
   params:
     # Just stdout it, so we can pipe it into the next tool
-    output_uri: "/tmp/single.jsonlines"
+    output_uri: "-"

--- a/thebeast/tests/sample/mappings/ukrainian_mps_multiprocess.yaml
+++ b/thebeast/tests/sample/mappings/ukrainian_mps_multiprocess.yaml
@@ -164,4 +164,4 @@ dump:
   cls: thebeast.dump.FTMLinesWriter
   params:
     # Just stdout it, so we can pipe it into the next tool
-    output_uri: "/tmp/multi.jsonlines"
+    output_uri: "-"


### PR DESCRIPTION
Not sure if that was intended, but sample mapping outputs was pointed to `/tmp/` instead of `stdout`. 