### PR TITLE
Major refactoring of digest class, entity reference resolution is now…

### DIFF
--- a/thebeast/contrib/ftm_ext/rigged_entity_proxy.py
+++ b/thebeast/contrib/ftm_ext/rigged_entity_proxy.py
@@ -72,7 +72,6 @@ class RiggedEntityProxy(EntityProxy):
         fuzzy: bool = False,
         format: Optional[str] = None,
     ) -> None:
-
         if not cleaned and value is not None:
             if isinstance(value, str):
                 value = StrProxy(value)

--- a/thebeast/digest/abstract.py
+++ b/thebeast/digest/abstract.py
@@ -73,10 +73,9 @@ def make_entities(
 
                     if prop.type == ENTITY_TYPE:
                         for val in entity.get(property_name):
-                            key_values += context_entities_map[val]
+                            key_values.append(context_entities_map.get(val))
                     else:
                         key_values += entity.get(property_name)
-
             elif key_type == "variable":
                 key_values += variables.get(key_path)
             elif key_type == "record":

--- a/thebeast/digest/abstract.py
+++ b/thebeast/digest/abstract.py
@@ -13,7 +13,7 @@ from .utils import (
     ensure_list,
     resolve_callable,
     deflate_entity,
-    ENTITY_TYPE
+    ENTITY_TYPE,
 )
 from .resolvers import resolve_property_values, resolve_constant_meta_values, resolve_collection_meta_values
 

--- a/thebeast/digest/abstract.py
+++ b/thebeast/digest/abstract.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Generator, Iterable, Callable, Optional, Any
+from typing import List, Dict, Generator, Iterable, Callable, Optional, Any, Union, Tuple
 
 from followthemoney.schema import Schema  # type: ignore
 
@@ -13,16 +13,23 @@ from .utils import (
     ensure_list,
     resolve_callable,
     deflate_entity,
+    ENTITY_TYPE
 )
 from .resolvers import resolve_property_values, resolve_constant_meta_values, resolve_collection_meta_values
 
 
 def make_entities(
-    record: Record, entities_config: Dict, statements_meta: Dict[str, str]
-) -> Generator[Schema, None, None]:
+    record: Union[List, Dict],
+    entities_config: Dict,
+    statements_meta: Dict[str, str],
+    parent_context_entities_map: Dict[str, Schema],
+) -> Tuple[List[Schema], Dict[str, Schema]]:
     """
     Takes the list/dict of records and a config for collection and produces entites
     """
+
+    context_entities_map: Dict[str, str] = parent_context_entities_map.copy()
+    context_entities: List[Schema] = []
 
     for entity_name, entity_config in entities_config.items():
         entity = make_entity(entity_config["schema"], key_prefix=entity_name)
@@ -54,7 +61,22 @@ def make_entities(
         for key in entity_config["keys"]:
             key_type, key_path = key.split(".", 1)
             if key_type == "entity":
-                key_values += entity.get(key_path)
+                properties_to_use: List[str] = []
+
+                if key_path == "*":
+                    properties_to_use = sorted(entity.properties)
+                else:
+                    properties_to_use = [key_path]
+
+                for property_name in properties_to_use:
+                    prop = entity.schema.properties[property_name]
+
+                    if prop.type == ENTITY_TYPE:
+                        for val in entity.get(property_name):
+                            key_values += context_entities_map[val]
+                    else:
+                        key_values += entity.get(property_name)
+
             elif key_type == "variable":
                 key_values += variables.get(key_path)
             elif key_type == "record":
@@ -62,7 +84,10 @@ def make_entities(
 
         entity.make_id(*key_values)
 
-        yield entity
+        context_entities_map[generate_pseudo_id(entity.key_prefix)] = entity.id
+        context_entities.append(entity)
+
+    return list(resolve_entity_refs(context_entities, context_entities_map)), context_entities_map
 
 
 def main_cog(
@@ -104,15 +129,15 @@ def main_cog(
             combined_statements_meta: Dict[str, str] = statements_meta.copy()
             combined_statements_meta.update(local_statements_meta)
 
-            local_context_entities: Dict[str, Schema] = {}
-            for entity in make_entities(record, collection_config["entities"], combined_statements_meta):
-                local_context_entities[generate_pseudo_id(entity.key_prefix)] = entity
+            local_context_entities, combined_context_entites_map = make_entities(
+                record,
+                collection_config["entities"],
+                statements_meta=combined_statements_meta,
+                parent_context_entities_map=parent_context_entities_map,
+            )
 
-            combined_context_entites_map: Dict[str, Schema] = parent_context_entities_map.copy()
-            combined_context_entites_map.update({k: v.id for k, v in local_context_entities.items()})
-
-            for entity in resolve_entity_refs(local_context_entities.values(), combined_context_entites_map):
-                # We are conveting entities from Schema to Dict here to overcome
+            for entity in local_context_entities:
+                # We are converting entities from Schema to Dict here to overcome
                 # an issue with circular references during pickling (also it'll reduce)
                 # the amount of data needs to be transfered between processed, since
                 # each process now has it's own FTM model and you don't need to
@@ -155,19 +180,14 @@ class AbstractDigestor:
         )
 
         # Then let's yield constant entities
-        context_entities_map: Dict[str, str] = {}
-        context_entities: List[Schema] = []
+        context_entities, context_entities_map = make_entities(
+            record={},
+            entities_config=self.mapping_config.get("constant_entities", {}),
+            statements_meta=statements_meta,
+            parent_context_entities_map={},
+        )
 
-        # TODO: use a dedicated function to make constant entities maybe?
-        for entity in make_entities(
-            record={}, entities_config=self.mapping_config.get("constant_entities", {}), statements_meta=statements_meta
-        ):
-            context_entities_map[generate_pseudo_id(entity.key_prefix)] = entity.id
-            context_entities.append(entity)
-
-        # And resolve entity refererence in constant entities (i.e one constant entity is referencing
-        # another in the property)
-        for entity in resolve_entity_refs(context_entities, context_entities_map):
+        for entity in context_entities:
             yield deflate_entity(entity)
 
         for entity in self.run_the_cog(

--- a/thebeast/digest/utils.py
+++ b/thebeast/digest/utils.py
@@ -95,9 +95,13 @@ def inflate_entity(entity_dict: Dict) -> RiggedEntityProxy:
 def deflate_entity(entity: RiggedEntityProxy) -> RedGreenEntity:
     asdict: Dict = entity.to_dict()
     valid: bool = True
-    try:
-        entity.schema.validate(asdict)
-    except InvalidData:
+
+    if entity.id is None:
         valid = False
+    else:
+        try:
+            entity.schema.validate(asdict)
+        except InvalidData:
+            valid = False
 
     return RedGreenEntity(payload=asdict, valid=valid)

--- a/thebeast/tests/sample/mappings/keys_resolver/asterisk_keys.yaml
+++ b/thebeast/tests/sample/mappings/keys_resolver/asterisk_keys.yaml
@@ -1,0 +1,33 @@
+id: asterisk_keys
+
+info:
+  comments: Config for testing asterisk/wildcard keys resolver
+  author: wm
+
+ingest:
+  cls: thebeast.ingest.TSVDictGlobReader
+  params:
+    input_uri: thebeast/tests/sample/csv/rada*.tsv
+
+digest:
+  collections:
+    root:
+      path: "[@]"
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.*
+          properties:
+            name:
+              column: name
+            birthDate:
+              column: birth_date
+            notes:
+              column: notes
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/keys_resolver/entity_keys.yaml
+++ b/thebeast/tests/sample/mappings/keys_resolver/entity_keys.yaml
@@ -1,0 +1,48 @@
+id: entity_keys
+
+info:
+  comments: Config for testing entity keys resolver
+  author: wm
+
+ingest:
+  cls: thebeast.ingest.TSVDictGlobReader
+  params:
+    input_uri: thebeast/tests/sample/csv/rada*.tsv
+
+digest:
+  collections:
+    root:
+      path: "[@]"
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+
+        company:
+          schema: Company
+          keys:
+            - entity.*
+          properties:
+            name:
+              column: company
+
+        employ:
+          schema: Employment
+          keys:
+            - entity.employee
+            - entity.employer
+          properties:
+            employee:
+              entity: person
+            employer:
+              entity: company
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard.yaml
+++ b/thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard.yaml
@@ -1,0 +1,47 @@
+id: entity_keys
+
+info:
+  comments: Config for testing entity keys resolver
+  author: wm
+
+ingest:
+  cls: thebeast.ingest.TSVDictGlobReader
+  params:
+    input_uri: thebeast/tests/sample/csv/rada*.tsv
+
+digest:
+  collections:
+    root:
+      path: "[@]"
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+
+        company:
+          schema: Company
+          keys:
+            - entity.*
+          properties:
+            name:
+              column: company
+
+        employ:
+          schema: Employment
+          keys:
+            - entity.*
+          properties:
+            employee:
+              entity: person
+            employer:
+              entity: company
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard_shuffled.yaml
+++ b/thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard_shuffled.yaml
@@ -1,0 +1,47 @@
+id: entity_keys
+
+info:
+  comments: Config for testing entity keys resolver
+  author: wm
+
+ingest:
+  cls: thebeast.ingest.TSVDictGlobReader
+  params:
+    input_uri: thebeast/tests/sample/csv/rada*.tsv
+
+digest:
+  collections:
+    root:
+      path: "[@]"
+
+      entities:
+        employ:
+          schema: Employment
+          keys:
+            - entity.*
+          properties:
+            employee:
+              entity: person
+            employer:
+              entity: company
+
+        company:
+          schema: Company
+          keys:
+            - entity.*
+          properties:
+            name:
+              column: company
+
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/keys_resolver/manual_keys.yaml
+++ b/thebeast/tests/sample/mappings/keys_resolver/manual_keys.yaml
@@ -1,0 +1,34 @@
+id: asterisk_keys_manual
+
+info:
+  comments: Config for testing asterisk/wildcard keys resolver
+  author: wm
+
+ingest:
+  cls: thebeast.ingest.TSVDictGlobReader
+  params:
+    input_uri: thebeast/tests/sample/csv/rada*.tsv
+
+digest:
+  collections:
+    root:
+      path: "[@]"
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.birthDate
+            - entity.name
+          properties:
+            name:
+              column: name
+            birthDate:
+              column: birth_date
+            notes:
+              column: notes
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/test_entity_keys.py
+++ b/thebeast/tests/test_entity_keys.py
@@ -76,27 +76,35 @@ class EntityKeysTests(unittest.TestCase):
                 Record(payload={"name": "Ivan Sraka"}),
             ]
 
-            entities = list(ent.payload for ent in mapping.digestor.extract(items))
+            entities = [*mapping.digestor.extract(items)]
             self.assertEqual(6, len(entities))
 
-            self.assertEqual("Person", entities[0]["schema"])
-            self.assertEqual("Company", entities[1]["schema"])
-            self.assertEqual("Employment", entities[2]["schema"])
+            self.assertEqual("Person", entities[0].payload["schema"])
+            self.assertEqual("Company", entities[1].payload["schema"])
+            self.assertEqual("Employment", entities[2].payload["schema"])
 
-            self.assertEqual("17dec550a297076989f408f075db145c3f72b80a", entities[0]["id"])
-            self.assertEqual("178e4423135e4b92d81049984b41ff524c1f5641", entities[1]["id"])
-            self.assertEqual("60781e1346aa5d396d3d6ed19743f8ae91dc9058", entities[2]["id"])
+            self.assertTrue(entities[0].valid)
+            self.assertTrue(entities[1].valid)
+            self.assertTrue(entities[2].valid)
 
-            self.assertEqual("Person", entities[3]["schema"])
-            self.assertEqual("Company", entities[4]["schema"])
-            self.assertEqual("Employment", entities[5]["schema"])
+            self.assertEqual("17dec550a297076989f408f075db145c3f72b80a", entities[0].payload["id"])
+            self.assertEqual("178e4423135e4b92d81049984b41ff524c1f5641", entities[1].payload["id"])
+            self.assertEqual("60781e1346aa5d396d3d6ed19743f8ae91dc9058", entities[2].payload["id"])
+
+            self.assertEqual("Person", entities[3].payload["schema"])
+            self.assertEqual("Company", entities[4].payload["schema"])
+            self.assertEqual("Employment", entities[5].payload["schema"])
+
+            self.assertTrue(entities[3].valid)
+            self.assertFalse(entities[4].valid)
+            self.assertFalse(entities[5].valid)
 
             # person keys are the same
-            self.assertEqual(entities[0]["id"], entities[3]["id"])
+            self.assertEqual(entities[0].payload["id"], entities[3].payload["id"])
             # second `company` is not generated
-            self.assertEqual(None, entities[4]["id"], entities[4])
+            self.assertEqual(None, entities[4].payload["id"])
             # `employment` id will differ because second company entity is not degenerated
-            self.assertNotEqual(entities[2]["id"], entities[5]["id"])
+            self.assertNotEqual(entities[2].payload["id"], entities[5].payload["id"])
 
     def test_entity_keys_on_entity_field_with_wrong_mapping_entity_order(self):
         mapping = SourceMapping(Path("thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard_shuffled.yaml"))
@@ -106,20 +114,24 @@ class EntityKeysTests(unittest.TestCase):
             Record(payload={"name": "Ivan Sraka"}),
         ]
 
-        entities = list(ent.payload for ent in mapping.digestor.extract(items))
+        entities = [*mapping.digestor.extract(items)]
         self.assertEqual(6, len(entities))
 
-        self.assertEqual("Employment", entities[0]["schema"])
-        self.assertEqual("Company", entities[1]["schema"])
-        self.assertEqual("Person", entities[2]["schema"])
+        self.assertEqual("Employment", entities[0].payload["schema"])
+        self.assertEqual("Company", entities[1].payload["schema"])
+        self.assertEqual("Person", entities[2].payload["schema"])
 
         # both employment ids will be `None` since it can't resolve it's related entities, being before them in mapping
-        self.assertEqual(None, entities[0]["id"])
-        self.assertEqual(None, entities[3]["id"])
+        self.assertEqual(None, entities[0].payload["id"])
+        self.assertEqual(None, entities[3].payload["id"])
 
-        self.assertEqual("178e4423135e4b92d81049984b41ff524c1f5641", entities[1]["id"])
-        self.assertEqual("17dec550a297076989f408f075db145c3f72b80a", entities[2]["id"])
+        # also ensure these entities are invalid
+        self.assertFalse(entities[0].valid)
+        self.assertFalse(entities[3].valid)
+
+        self.assertEqual("17dec550a297076989f408f075db145c3f72b80a", entities[2].payload["id"])
 
         # Second `Company` is also None since it's empty
-        self.assertEqual(None, entities[4]["id"])
-        self.assertEqual(entities[2]["id"], entities[5]["id"])
+        self.assertEqual(None, entities[4].payload["id"])
+        self.assertFalse(entities[4].valid)
+        self.assertEqual(entities[2].payload["id"], entities[5].payload["id"])

--- a/thebeast/tests/test_entity_keys.py
+++ b/thebeast/tests/test_entity_keys.py
@@ -1,0 +1,125 @@
+import unittest
+import json
+from pathlib import Path
+from collections import defaultdict
+from typing import Dict, List
+
+from followthemoney.schema import Schema  # type: ignore
+from thebeast.types import Record
+from thebeast.conf.mapping import SourceMapping
+from thebeast.contrib.ftm_ext import meta_factory
+
+"""
+  Tests for entity keys resolvers
+"""
+
+
+class EntityKeysTests(unittest.TestCase):
+    def test_asterisk_key_generator(self):
+        mapping = SourceMapping(Path("thebeast/tests/sample/mappings/keys_resolver/asterisk_keys.yaml"))
+
+        items = [
+            Record(payload={"name": "Ющенко Віктор Андрійович"}),
+            Record(payload={"name": "Ющенко Віктор Андрійович", "birth_date": "1954-02-23"}),
+            Record(
+                payload={
+                    "name": "Ющенко Віктор Андрійович",
+                    "birth_date": "1954-02-23",
+                    "notes": "Третій Президент України",
+                }
+            ),
+        ]
+
+        entities = list(ent.payload for ent in mapping.digestor.extract(items))
+        self.assertEqual(3, len(entities))
+
+        # ids must differ with each row
+        self.assertEqual("c1d4c4652b8b9a8d5cda22d508e497a12dd9d07f", entities[0]["id"])
+        self.assertEqual("c131fc0732f46173b22c8698d0cc5d0d220a7932", entities[1]["id"])
+        self.assertEqual("4de61b4fc100bf0a397898a5067be46a28e26a16", entities[2]["id"])
+
+    def test_asterisk_key_resolver_returns_same_keys_as_manual(self):
+        asterisk_mapping = SourceMapping(Path("thebeast/tests/sample/mappings/keys_resolver/asterisk_keys.yaml"))
+        manual_mapping = SourceMapping(Path("thebeast/tests/sample/mappings/keys_resolver/manual_keys.yaml"))
+
+        items = [
+            Record(payload={"name": "Ющенко Віктор Андрійович"}),
+            Record(payload={"name": "Ющенко Віктор Андрійович", "birth_date": "1954-02-23"}),
+            Record(
+                payload={
+                    "name": "Ющенко Віктор Андрійович",
+                    "birth_date": "1954-02-23",
+                    "notes": "Третій Президент України",
+                }
+            ),
+        ]
+
+        asterisk_entities = list(ent.payload for ent in asterisk_mapping.digestor.extract(items))
+        manual_entities = list(ent.payload for ent in manual_mapping.digestor.extract(items))
+
+        # keys will be same for 1st and 2nd rows because both have the same keys
+        self.assertEqual(manual_entities[0]["id"], asterisk_entities[0]["id"])
+        self.assertEqual(manual_entities[1]["id"], asterisk_entities[1]["id"])
+
+        # manual_keys will ignore `notes`, so keys will differ
+        self.assertNotEqual(manual_entities[2]["id"], asterisk_entities[2]["id"])
+
+    def test_entity_keys_on_entity_field(self):
+        for path in [
+            Path("thebeast/tests/sample/mappings/keys_resolver/entity_keys.yaml"),
+            Path("thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard.yaml"),
+        ]:
+            mapping = SourceMapping(path)
+
+            items = [
+                Record(payload={"name": "Ivan Sraka", "company": "Sraka, LTD."}),
+                Record(payload={"name": "Ivan Sraka"}),
+            ]
+
+            entities = list(ent.payload for ent in mapping.digestor.extract(items))
+            self.assertEqual(6, len(entities))
+
+            self.assertEqual("Person", entities[0]["schema"])
+            self.assertEqual("Company", entities[1]["schema"])
+            self.assertEqual("Employment", entities[2]["schema"])
+
+            self.assertEqual("17dec550a297076989f408f075db145c3f72b80a", entities[0]["id"])
+            self.assertEqual("178e4423135e4b92d81049984b41ff524c1f5641", entities[1]["id"])
+            self.assertEqual("60781e1346aa5d396d3d6ed19743f8ae91dc9058", entities[2]["id"])
+
+            self.assertEqual("Person", entities[3]["schema"])
+            self.assertEqual("Company", entities[4]["schema"])
+            self.assertEqual("Employment", entities[5]["schema"])
+
+            # person keys are the same
+            self.assertEqual(entities[0]["id"], entities[3]["id"])
+            # second `company` is not generated
+            self.assertEqual(None, entities[4]["id"], entities[4])
+            # `employment` id will differ because second company entity is not degenerated
+            self.assertNotEqual(entities[2]["id"], entities[5]["id"])
+
+    def test_entity_keys_on_entity_field_with_wrong_mapping_entity_order(self):
+        mapping = SourceMapping(Path("thebeast/tests/sample/mappings/keys_resolver/entity_keys_wildcard_shuffled.yaml"))
+
+        items = [
+            Record(payload={"name": "Ivan Sraka", "company": "Sraka, LTD."}),
+            Record(payload={"name": "Ivan Sraka"}),
+        ]
+
+        entities = list(ent.payload for ent in mapping.digestor.extract(items))
+        self.assertEqual(6, len(entities))
+
+        self.assertEqual("Employment", entities[0]["schema"])
+        self.assertEqual("Company", entities[1]["schema"])
+        self.assertEqual("Person", entities[2]["schema"])
+
+        # both employment ids will be `None` since it can't resolve it's related entities, being before them in mapping
+        self.assertEqual(None, entities[0]["id"])
+        self.assertEqual(None, entities[3]["id"])
+
+        self.assertEqual("178e4423135e4b92d81049984b41ff524c1f5641", entities[1]["id"])
+        self.assertEqual("17dec550a297076989f408f075db145c3f72b80a", entities[2]["id"])
+
+        # Second `Company` is also None since it's empty
+        self.assertEqual(None, entities[4]["id"])
+        self.assertEqual(entities[2]["id"], entities[5]["id"])


### PR DESCRIPTION
… done inside the make_entities helper, signature of the helper changed too, entity id keys now might include links to other entities with proper dereferencing. Also * is now supported in the entity.* syntax of keys