### PR TITLE
Some fixes to `info` block validator in the mapping definition.

### DIFF
--- a/thebeast/conf/mapping_validator.json
+++ b/thebeast/conf/mapping_validator.json
@@ -546,9 +546,30 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "maintainer":
+                {
+                    "description": "Optional reference to the maintainers of this mapping",
+                    "type": "string"
+                },
                 "modified":
                 {
                     "format": "date-time",
+                    "type": "string"
+                },
+                "publisher":
+                {
+                    "description": "Optional reference to publisher of source data",
+                    "type": "string"
+                },
+                "tags":
+                {
+                    "description": "Optional arbitrary list of mapping tags, e.g. 'unofficial', 'government', etc",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "title":
+                {
+                    "description": "Optional title for the mapping",
                     "type": "string"
                 }
             },

--- a/thebeast/tests/sample/mappings/invalid_properties_info_1.yaml
+++ b/thebeast/tests/sample/mappings/invalid_properties_info_1.yaml
@@ -1,0 +1,45 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Dmytro Chaplynskyi
+  created: "2023-01-02T20:19:00.1Z"
+  modified: "2023-01-02T20:19:00.1Z"
+  tags: "foo bar"
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: thebeast/tests/sample/json/ru_mayors.jsonl
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        ru_mayor:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: mayorLabel
+              transformer: thebeast.contrib.transformers.mixed_charset_fixer
+            title:
+              template: "Мер, {{ record.itemLabel }}"
+            sourceUrl:
+              column: mayor
+            birthDate:
+              column: birth_date
+            birthPlace:
+              column: birth_placeLabel
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/invalid_properties_info_2.yaml
+++ b/thebeast/tests/sample/mappings/invalid_properties_info_2.yaml
@@ -1,0 +1,47 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Dmytro Chaplynskyi
+  created: "2023-01-02T20:19:00.1Z"
+  modified: "2023-01-02T20:19:00.1Z"
+  tags: 
+    - foo
+    - foo
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: thebeast/tests/sample/json/ru_mayors.jsonl
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        ru_mayor:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: mayorLabel
+              transformer: thebeast.contrib.transformers.mixed_charset_fixer
+            title:
+              template: "Мер, {{ record.itemLabel }}"
+            sourceUrl:
+              column: mayor
+            birthDate:
+              column: birth_date
+            birthPlace:
+              column: birth_placeLabel
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/ukrainian_edr.yaml
+++ b/thebeast/tests/sample/mappings/ukrainian_edr.yaml
@@ -2,10 +2,17 @@ id: ukrainian_edr
 # ftm_ontology: # Again optional path to the directory with ftm
 
 info:
+  title: Ukrainian EDR data
   comments: Optional comments on the data source
   author: Daniel Horbunov, Dmytro Chaplynskyi
+  maintainer: Dmytro Chaplynskyi
+  publisher: Ministry of Justice of Ukraine
   created: "2022-06-20T20:19:00.1Z"
-  modified: "2022-06-20T20:19:00.1Z"
+  modified: "2023-02-26T21:40:00.1Z"
+  tags:
+    - companies
+    - official-source
+    - sample-mapping
 
 ingest:
   cls: thebeast.ingest.JSONGlobReader

--- a/thebeast/tests/test_configure.py
+++ b/thebeast/tests/test_configure.py
@@ -58,6 +58,8 @@ class MappingReaderTests(unittest.TestCase):
             "invalid_properties_4.yaml",
             "invalid_properties_5.yaml",
             "invalid_properties_6.yaml",
+            "invalid_properties_info_1.yaml",
+            "invalid_properties_info_2.yaml",
         ]:
             with self.assertRaises(InvalidMappingException):
                 SourceMapping(Path(f"thebeast/tests/sample/mappings/{mapping_fname}"))


### PR DESCRIPTION
Added some keys to validator, so we all can have a nice mapping metadata. 🥳