### PR TITLE
Added new transformers

### DIFF
--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -4,6 +4,7 @@ from dateutil.parser import parse as dt_parse  # type: ignore
 from names_translator.name_utils import try_to_fix_mixed_charset, parse_and_generate  # type: ignore
 from thebeast.contrib.ftm_ext.rigged_entity_proxy import StrProxy
 import regex as re
+import html
 
 
 # TODO: split into dates/names/others files
@@ -91,3 +92,11 @@ def do_normalize_email(value: str) -> str:
 
 def normalize_email(values: List[StrProxy]) -> List[StrProxy]:
     return [value.inject_meta_to_str(do_normalize_email(value)) for value in values]
+
+
+def decode_html_entities(values: List[StrProxy]) -> List[StrProxy]:
+    """
+    Decode HTML entities
+    """
+
+    return [value.inject_meta_to_str(html.unescape(value)) for value in values]

--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -100,3 +100,20 @@ def decode_html_entities(values: List[StrProxy]) -> List[StrProxy]:
     """
 
     return [value.inject_meta_to_str(html.unescape(value)) for value in values]
+
+
+def do_pad_string(value: str, length, pad_char=" ", align="left") -> str:
+    if align == "left":
+        return value.ljust(length, pad_char)
+    elif align == "right":
+        return value.rjust(length, pad_char)
+    else:
+        raise ValueError("Invalid align value, expecting left or right")
+
+
+def pad_string(values: List[StrProxy], length, pad_char=" ", align="left") -> List[StrProxy]:
+    """
+    Pad string to desired length
+    """
+
+    return [value.inject_meta_to_str(do_pad_string(value, int(length), pad_char, align)) for value in values]

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -95,3 +95,27 @@ class ResolversTests(unittest.TestCase):
 
                 actual_result = _resolve_transformer({"name": "thebeast.contrib.transformers.normalize_email"}, ctx)[0]
                 self.assertEqual(actual_result, expected_result)
+
+    def test_decode_html_entities(self):
+        param_list = [
+            (StrProxy("foobar"), "foobar"),
+            (StrProxy("<foobar>"), "<foobar>"),
+            (StrProxy("&lt;foobar&#62;"), "<foobar>"),
+        ]
+
+        ctx = ResolveContext(
+            record={},
+            property_values=[],
+            entity=None,
+            statements_meta={},
+            variables={},
+        )
+
+        for input_val, expected_result in param_list:
+            with self.subTest():
+                ctx.property_values = [StrProxy(input_val)]
+
+                actual_result = _resolve_transformer(
+                    {"name": "thebeast.contrib.transformers.decode_html_entities"}, ctx
+                )[0]
+                self.assertEqual(actual_result, expected_result)

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -119,3 +119,36 @@ class ResolversTests(unittest.TestCase):
                     {"name": "thebeast.contrib.transformers.decode_html_entities"}, ctx
                 )[0]
                 self.assertEqual(actual_result, expected_result)
+
+    def test_pad_string(self):
+        ctx = ResolveContext(
+            record={},
+            property_values=[],
+            entity=None,
+            statements_meta={},
+            variables={},
+        )
+
+        ctx.property_values = [StrProxy("1234")]
+        actual_result = _resolve_transformer(
+            {"name": "thebeast.contrib.transformers.pad_string", "params": {"length": "5", "pad_char": "0"}}, ctx
+        )[0]
+        self.assertEqual(actual_result, "12340")
+
+        ctx.property_values = [StrProxy("1234")]
+        actual_result = _resolve_transformer(
+            {
+                "name": "thebeast.contrib.transformers.pad_string",
+                "params": {"length": "5", "pad_char": "5", "align": "right"},
+            },
+            ctx,
+        )[0]
+        self.assertEqual(actual_result, "51234")
+
+        ctx.property_values = [StrProxy("1234")]
+        self.assertRaises(
+            ValueError,
+            _resolve_transformer,
+            {"name": "thebeast.contrib.transformers.pad_string", "params": {"length": "5", "align": "foobar"}},
+            ctx,
+        )


### PR DESCRIPTION
Added `decode_html_entities` to decode html-encoded values (`&gt;` ➡`>`).

Added `pad_string` to (wow such surprise) pad strings left or right. 

Pls take a look on `do_pad_string`, I'm not sure I'm following best practices there. 