### PR TITLE
Allow GH action to run on pull requests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: The Beast package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
You've set up your gh actions to run only on `push` event, so prs remains uncovered. 

Now they won't.