### PR TITLE
Add `from unixtime` transformer and fix `anydate`

### DIFF
--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -41,11 +41,23 @@ def mixed_charset_fixer(values: List[StrProxy]) -> List[StrProxy]:
     return [value.inject_meta_to_str(try_to_fix_mixed_charset(value)) for value in values]
 
 
-def anydate_parser(values: List[StrProxy], **kwargs) -> List[StrProxy]:
+def anydate_parser(values: List[StrProxy], silent=False, **kwargs) -> List[StrProxy]:
     """
     Trying to parse date with dateutil lib
     """
-    return [value.inject_meta_to_str(dt_parse(value, **kwargs).date()) for value in values]
+
+    res = []
+
+    for value in values:
+        try:
+            res.append(value.inject_meta_to_str(dt_parse(value, **kwargs).date()))
+        except Exception:
+            if silent:
+                pass
+            else:
+                raise
+
+    return res
 
 
 def anydatetime_parser(values: List[StrProxy], **kwargs) -> List[StrProxy]:

--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -1,5 +1,6 @@
 from typing import List
 from dateutil.parser import parse as dt_parse  # type: ignore
+import datetime
 
 from names_translator.name_utils import try_to_fix_mixed_charset, parse_and_generate  # type: ignore
 from thebeast.contrib.ftm_ext.rigged_entity_proxy import StrProxy
@@ -52,6 +53,25 @@ def anydatetime_parser(values: List[StrProxy], **kwargs) -> List[StrProxy]:
     Trying to parse datetime with dateutil lib
     """
     return [value.inject_meta_to_str(dt_parse(value, **kwargs)) for value in values]
+
+
+def from_unixtime(values: List[StrProxy], silent=False) -> List[StrProxy]:
+    """
+    Trying to create datetime from unix timestamp
+    """
+
+    res = []
+
+    for value in values:
+        try:
+            res.append(value.inject_meta_to_str(datetime.datetime.fromtimestamp(int(value))))
+        except Exception:
+            if silent:
+                pass
+            else:
+                raise
+
+    return res
 
 
 def incomplete_date_converter(value: str) -> str:

--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -67,7 +67,7 @@ def anydatetime_parser(values: List[StrProxy], **kwargs) -> List[StrProxy]:
     return [value.inject_meta_to_str(dt_parse(value, **kwargs)) for value in values]
 
 
-def from_unixtime(values: List[StrProxy], silent=False) -> List[StrProxy]:
+def from_unixtime(values: List[StrProxy], silent=False, skip_zero_date=True) -> List[StrProxy]:
     """
     Trying to create datetime from unix timestamp
     """
@@ -76,6 +76,9 @@ def from_unixtime(values: List[StrProxy], silent=False) -> List[StrProxy]:
 
     for value in values:
         try:
+            if skip_zero_date and int(value) == 0:
+                continue
+
             res.append(value.inject_meta_to_str(datetime.datetime.fromtimestamp(int(value))))
         except Exception:
             if silent:

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -11,41 +11,59 @@ class ResolversTests(unittest.TestCase):
     def test_anydate_parser(self):
         ctx = ResolveContext(
             record={},
-            property_values=[StrProxy("05.06.07")],
+            property_values=[],
             entity=None,
             statements_meta={},
             variables={},
         )
 
-        val = _resolve_transformer("thebeast.contrib.transformers.anydate_parser", ctx)[0]
-        self.assertIsInstance(val, StrProxy)
-        self.assertEqual(val, "2007-05-06")
-        self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser()")
+        with self.subTest("Test anydate_parser"):
+            ctx.property_values = [StrProxy("05.06.07")]
+            val = _resolve_transformer("thebeast.contrib.transformers.anydate_parser", ctx)[0]
+            self.assertIsInstance(val, StrProxy)
+            self.assertEqual(val, "2007-05-06")
+            self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser()")
 
-        val = _resolve_transformer({"name": "thebeast.contrib.transformers.anydate_parser"}, ctx)[0]
-        self.assertEqual(val, "2007-05-06")
-        self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser()")
+            val = _resolve_transformer({"name": "thebeast.contrib.transformers.anydate_parser"}, ctx)[0]
+            self.assertEqual(val, "2007-05-06")
+            self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser()")
 
-        val = _resolve_transformer(
-            {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"dayfirst": True}}, ctx
-        )[0]
-        self.assertEqual(val, "2007-06-05")
-        self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(dayfirst=True)")
+            val = _resolve_transformer(
+                {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"dayfirst": True}}, ctx
+            )[0]
+            self.assertEqual(val, "2007-06-05")
+            self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(dayfirst=True)")
 
-        val = _resolve_transformer(
-            {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"yearfirst": True}}, ctx
-        )[0]
-        self.assertEqual(val, "2005-06-07")
-        self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(yearfirst=True)")
+            val = _resolve_transformer(
+                {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"yearfirst": True}}, ctx
+            )[0]
+            self.assertEqual(val, "2005-06-07")
+            self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(yearfirst=True)")
 
-        ctx.property_values = [StrProxy("05.06.07", meta={"locale": "php"})]
+            ctx.property_values = [StrProxy("05.06.07", meta={"locale": "php"})]
 
-        val = _resolve_transformer(
-            {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"yearfirst": True}}, ctx
-        )[0]
-        self.assertEqual(val, "2005-06-07")
-        self.assertEqual(val._meta.locale, "php")
-        self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(yearfirst=True)")
+            val = _resolve_transformer(
+                {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"yearfirst": True}}, ctx
+            )[0]
+            self.assertEqual(val, "2005-06-07")
+            self.assertEqual(val._meta.locale, "php")
+            self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(yearfirst=True)")
+
+        with self.subTest("Test anydate_parser throws exception on invalid value"):
+            ctx.property_values = [StrProxy("fooBAR")]
+            self.assertRaises(
+                ValueError,
+                _resolve_transformer,
+                {"name": "thebeast.contrib.transformers.anydate_parser"},
+                ctx,
+            )
+
+        with self.subTest("Test error is not thrown with silent mode"):
+            ctx.property_values = [StrProxy("fooBAR")]
+            actual_result = _resolve_transformer(
+                {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"silent": True}}, ctx
+            )
+            self.assertEqual(actual_result, [])
 
     def test_trim_string(self):
         ctx = ResolveContext(

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -50,7 +50,7 @@ class ResolversTests(unittest.TestCase):
             self.assertEqual(val._meta.transformation, "thebeast.contrib.transformers.anydate_parser(yearfirst=True)")
 
         with self.subTest("Test anydate_parser throws exception on invalid value"):
-            ctx.property_values = [StrProxy("fooBAR")]
+            ctx.property_values = [StrProxy("05.06.07"), StrProxy("fooBAR")]
             self.assertRaises(
                 ValueError,
                 _resolve_transformer,
@@ -58,12 +58,12 @@ class ResolversTests(unittest.TestCase):
                 ctx,
             )
 
-        with self.subTest("Test error is not thrown with silent mode"):
-            ctx.property_values = [StrProxy("fooBAR")]
+        with self.subTest("Test error is not thrown with silent mode, and only invalid value is skipped"):
+            ctx.property_values = [StrProxy("05.06.07"), StrProxy("fooBAR")]
             actual_result = _resolve_transformer(
                 {"name": "thebeast.contrib.transformers.anydate_parser", "params": {"silent": True}}, ctx
             )
-            self.assertEqual(actual_result, [])
+            self.assertEqual(actual_result, ["2007-05-06"])
 
     def test_trim_string(self):
         ctx = ResolveContext(
@@ -233,7 +233,7 @@ class ResolversTests(unittest.TestCase):
             self.assertEqual(actual_result, ["1970-01-01 00:00:00", "2023-08-08 21:00:00"])
 
         with self.subTest("Test error is thrown without silent mode"):
-            ctx.property_values = [StrProxy("fooBAR")]
+            ctx.property_values = [StrProxy("1691528400"), StrProxy("fooBAR")]
             self.assertRaises(
                 ValueError,
                 _resolve_transformer,
@@ -241,9 +241,9 @@ class ResolversTests(unittest.TestCase):
                 ctx,
             )
 
-        with self.subTest("Test error is not thrown with silent mode"):
-            ctx.property_values = [StrProxy("fooBAR")]
+        with self.subTest("Test error is not thrown with silent mode, and only invalid value is skipped"):
+            ctx.property_values = [StrProxy("1691528400"), StrProxy("fooBAR")]
             actual_result = _resolve_transformer(
                 {"name": "thebeast.contrib.transformers.from_unixtime", "params": {"silent": True}}, ctx
             )
-            self.assertEqual(actual_result, [])
+            self.assertEqual(actual_result, ["2023-08-08 21:00:00"])

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -203,10 +203,7 @@ class ResolversTests(unittest.TestCase):
             )
 
     def test_from_unixtime(self):
-        param_list = [
-            ("1643839200", "2022-02-02 22:00:00"),
-            ("1643895202", "2022-02-03 13:33:22"),
-        ]
+        param_list = [("1643839200", "2022-02-02 22:00:00"), ("1643895202", "2022-02-03 13:33:22")]
 
         ctx = ResolveContext(
             record={},
@@ -222,6 +219,18 @@ class ResolversTests(unittest.TestCase):
                 actual_result = _resolve_transformer({"name": "thebeast.contrib.transformers.from_unixtime"}, ctx)[0]
                 self.assertEqual(actual_result, expected_result)
                 self.assertEqual(actual_result._meta.transformation, "thebeast.contrib.transformers.from_unixtime()")
+
+        with self.subTest("Zero unixtime is ignored by default"):
+            ctx.property_values = [StrProxy("0"), StrProxy("1691528400")]
+            actual_result = _resolve_transformer({"name": "thebeast.contrib.transformers.from_unixtime"}, ctx)
+            self.assertEqual(actual_result, ["2023-08-08 21:00:00"])
+
+        with self.subTest("Zero unixtime is not ignored if param is set"):
+            ctx.property_values = [StrProxy("0"), StrProxy("1691528400")]
+            actual_result = _resolve_transformer(
+                {"name": "thebeast.contrib.transformers.from_unixtime", "params": {"skip_zero_date": False}}, ctx
+            )
+            self.assertEqual(actual_result, ["1970-01-01 00:00:00", "2023-08-08 21:00:00"])
 
         with self.subTest("Test error is thrown without silent mode"):
             ctx.property_values = [StrProxy("fooBAR")]

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -183,3 +183,40 @@ class ResolversTests(unittest.TestCase):
                 {"name": "thebeast.contrib.transformers.convert_case", "params": {"case": "foobar"}},
                 ctx,
             )
+
+    def test_from_unixtime(self):
+        param_list = [
+            ("1643839200", "2022-02-02 22:00:00"),
+            ("1643895202", "2022-02-03 13:33:22"),
+        ]
+
+        ctx = ResolveContext(
+            record={},
+            property_values=[],
+            entity=None,
+            statements_meta={},
+            variables={},
+        )
+
+        for input_val, expected_result in param_list:
+            with self.subTest("Test date from unixtime", expected_result=expected_result):
+                ctx.property_values = [StrProxy(input_val)]
+                actual_result = _resolve_transformer({"name": "thebeast.contrib.transformers.from_unixtime"}, ctx)[0]
+                self.assertEqual(actual_result, expected_result)
+                self.assertEqual(actual_result._meta.transformation, "thebeast.contrib.transformers.from_unixtime()")
+
+        with self.subTest("Test error is thrown without silent mode"):
+            ctx.property_values = [StrProxy("fooBAR")]
+            self.assertRaises(
+                ValueError,
+                _resolve_transformer,
+                {"name": "thebeast.contrib.transformers.from_unixtime", "params": {"silent": False}},
+                ctx,
+            )
+
+        with self.subTest("Test error is not thrown with silent mode"):
+            ctx.property_values = [StrProxy("fooBAR")]
+            actual_result = _resolve_transformer(
+                {"name": "thebeast.contrib.transformers.from_unixtime", "params": {"silent": True}}, ctx
+            )
+            self.assertEqual(actual_result, [])


### PR DESCRIPTION
So, I needed a unix timestamp date input. 

I've made it error-proof, you can skip exceptions on bad input with `silent` param.

I've also did this for `anydate` in separate commit, since most of the time I really need to ignore errors with almost any input data I have. Hope you won't hate my approach. 