### PR TITLE
Fix `regex_replace` resolver

### DIFF
--- a/thebeast/conf/mapping_validator.json
+++ b/thebeast/conf/mapping_validator.json
@@ -328,10 +328,17 @@
                     "properties": {
                         "regex": {
                             "format": "regex",
-                            "type": "string"
+                            "type": [
+                                "string",
+                                "array"
+                            ]
                         },
                         "replace": {
-                            "type": "string"
+                            "type": "string",
+                             "type": [
+                                "string",
+                                "array"
+                            ]
                         }
                     },
                     "required":

--- a/thebeast/conf/mapping_validator.json
+++ b/thebeast/conf/mapping_validator.json
@@ -324,7 +324,7 @@
                 },
                 "regex_replace":
                 {
-                    "description": "regex to apply to extracted values for replacing substrings",
+                    "description": "regex or regex list to apply to extracted values for replacing substring(-s)",
                     "properties": {
                         "regex": {
                             "format": "regex",

--- a/thebeast/digest/resolvers.py
+++ b/thebeast/digest/resolvers.py
@@ -116,7 +116,12 @@ def _resolve_regex(command_config: CommandConfig, context: ResolveContext) -> Li
     return extracted_property_values
 
 
-def regex_replace_multiple(regex_list: list, replace_list: list, property_values: list):
+def regex_replace_multiple(regex_list: list, replace_list: list, property_values: list) -> List[StrProxy]:
+    """
+    `regex_list` is a list of regex expression to apply to input.
+    `replace list` is a list of replacement strings, it MUST have length equal to `regex_list`.
+    """
+
     extracted_property_values: List[Any] = []
 
     for property_value in property_values:
@@ -137,18 +142,21 @@ def _resolve_regex_replace(command_config: CommandConfig, context: ResolveContex
     """
     `regex_replace` is an optional regex **replacer** to replace content of extracted string.
 
-    todo: use simplier config with single param - regex - and default "replace" to (empty string) ?
-    i.e.: "regex_replace: \\d+" to remove all non-numeric symbols without having to specify long mapping
+    It accepts a single regex or regex list, and a single replace value or list of replaces for each given regex.
+    In case of single value, all regexes will be replaced with it. In other case, length of `replace` list must
+    be equal to length of `regex` list, or ValueError will be thrown.
+
+    fixme: can/should we validate both lengths in mapping_validator or keep it there?
     """
 
     extracted_property_values: List[Any] = []
     regex_list = command_config["regex"]
     replace = command_config["replace"]
 
-    if type(regex_list) != list:
+    if not isinstance(regex_list, list):
         regex_list = [regex_list]
 
-    if type(replace) == list:
+    if isinstance(replace, list):
         if len(replace) != len(regex_list):
             raise ValueError("If 'replace' is an array, it must have same length as 'regex'")
         else:
@@ -158,12 +166,10 @@ def _resolve_regex_replace(command_config: CommandConfig, context: ResolveContex
         if not property_value:
             continue
 
-        string = property_value
-
         for regex in regex_list:
-            string = property_value.inject_meta_to_str(re.sub(regex, replace, string, flags=re.V1))
+            property_value = property_value.inject_meta_to_str(re.sub(regex, replace, property_value, flags=re.V1))
 
-        extracted_property_values += [string]
+        extracted_property_values += [property_value]
 
     return extracted_property_values
 

--- a/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list.yaml
+++ b/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list.yaml
@@ -1,0 +1,43 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Wishmaster
+  created: "2023-08-10T15:19:00.1Z"
+  modified: "2023-08-10T15:19:00.1Z"
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: "-"
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+              regex_replace: 
+                regex: 
+                  - "NULL"
+                  - "empty"
+                replace: 
+                  - "foo"
+                  - "bar"
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list_invalid.yaml
+++ b/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list_invalid.yaml
@@ -1,0 +1,44 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Wishmaster
+  created: "2023-08-10T15:19:00.1Z"
+  modified: "2023-08-10T15:19:00.1Z"
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: "-"
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+              regex_replace: 
+                regex: 
+                  - "NULL"
+                  - "empty"
+                replace: 
+                  - "foo"
+                  - "bar"
+                  - "baz"
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list_invalid.yaml
+++ b/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list_invalid.yaml
@@ -29,9 +29,7 @@ digest:
             name:
               column: name
               regex_replace: 
-                regex: 
-                  - "NULL"
-                  - "empty"
+                regex: "empty"
                 replace: 
                   - "foo"
                   - "bar"

--- a/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list_invalid_2.yaml
+++ b/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_list_invalid_2.yaml
@@ -1,0 +1,44 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Wishmaster
+  created: "2023-08-10T15:19:00.1Z"
+  modified: "2023-08-10T15:19:00.1Z"
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: "-"
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+              regex_replace: 
+                regex: 
+                  - "NULL"
+                  - "empty"
+                replace: 
+                  - "foo"
+                  - "bar"
+                  - "baz"
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_string.yaml
+++ b/thebeast/tests/sample/mappings/regex_replace/regex_replace_list_to_string.yaml
@@ -1,0 +1,41 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Wishmaster
+  created: "2023-08-10T15:19:00.1Z"
+  modified: "2023-08-10T15:19:00.1Z"
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: "-"
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+              regex_replace: 
+                regex: 
+                  - "NULL"
+                  - "empty"
+                replace: ""
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/sample/mappings/regex_replace/regex_replace_string.yaml
+++ b/thebeast/tests/sample/mappings/regex_replace/regex_replace_string.yaml
@@ -1,0 +1,39 @@
+id: ru_mayors
+
+meta: []
+
+info:
+  comments: No meta test file
+  author: Wishmaster
+  created: "2023-08-10T15:19:00.1Z"
+  modified: "2023-08-10T15:19:00.1Z"
+
+ingest:
+  cls: thebeast.ingest.JSONLinesGlobReader
+  params:
+    input_uri: "-"
+digest:
+  meta:
+    locale:
+      literal: ru
+  collections:
+    root:
+      path: "[@]"   # Wrap each record into the list
+
+      entities:
+        person:
+          schema: Person
+          keys:
+            - entity.name
+          properties:
+            name:
+              column: name
+              regex_replace: 
+                regex: "NULL"
+                replace: ""
+
+dump:
+  cls: thebeast.dump.FTMLinesWriter
+  params:
+    # Just stdout it, so we can pipe it into the next tool
+    output_uri: "/dev/stdout"

--- a/thebeast/tests/test_configure.py
+++ b/thebeast/tests/test_configure.py
@@ -49,6 +49,18 @@ class MappingReaderTests(unittest.TestCase):
                 Path("thebeast/tests/sample/mappings/ukrainian_mps.yaml"), ingest_overrides={"input_uri": 1337}
             )
 
+    def test_regex_replace_mappings(self):
+        for mapping_fname in [
+            "regex_replace_string.yaml",
+            "regex_replace_list_to_string.yaml",
+            "regex_replace_list_to_list.yaml",
+            # both invalid mapping wont trigger InvalidMappingException, since their config is validated inside resolver logic
+            "regex_replace_list_to_list_invalid.yaml",
+            "regex_replace_list_to_list_invalid_2.yaml",
+        ]:
+            with self.subTest("Test mapping", file=mapping_fname):
+                SourceMapping(Path(f"thebeast/tests/sample/mappings/regex_replace/{mapping_fname}"))
+
     def test_invalid_mapping_properties(self):
         for mapping_fname in [
             "invalid.yaml",
@@ -61,5 +73,6 @@ class MappingReaderTests(unittest.TestCase):
             "invalid_properties_info_1.yaml",
             "invalid_properties_info_2.yaml",
         ]:
-            with self.assertRaises(InvalidMappingException):
-                SourceMapping(Path(f"thebeast/tests/sample/mappings/{mapping_fname}"))
+            with self.subTest("Test mapping", file=mapping_fname):
+                with self.assertRaises(InvalidMappingException):
+                    SourceMapping(Path(f"thebeast/tests/sample/mappings/{mapping_fname}"))


### PR DESCRIPTION
I've made some fixes to `regex_replace`, so it's now accepting lists as inputs, see #32 for details.

Not sure if I like to replace a small 'thin' resolver with two methods and 50 lines of code, so looking for your review.