### PR TITLE
Add `normalize_phone` transformer.

### DIFF
--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -143,6 +143,17 @@ def normalize_email(values: List[StrProxy]) -> List[StrProxy]:
     return [value.inject_meta_to_str(do_normalize_email(value)) for value in values]
 
 
+def normalize_phone(values: List[StrProxy]) -> List[StrProxy]:
+    """
+    Normalizes phone number, prepending a plus symbol to it.
+    This is needed because FtM expects phone to start with plus, and phones with just nmumbers will be skipepd.
+
+    For example:
+        79787458007 => +79787458007
+    """
+    return [value.inject_meta_to_str("+" + value) if not value.startswith("+") else value for value in values]
+
+
 def decode_html_entities(values: List[StrProxy]) -> List[StrProxy]:
     """
     Decode HTML entities

--- a/thebeast/tests/test_resolvers_transformers.py
+++ b/thebeast/tests/test_resolvers_transformers.py
@@ -114,6 +114,30 @@ class ResolversTests(unittest.TestCase):
                 actual_result = _resolve_transformer({"name": "thebeast.contrib.transformers.normalize_email"}, ctx)[0]
                 self.assertEqual(actual_result, expected_result)
 
+    def test_normalize_phone(self):
+        param_list = [
+            (StrProxy("1234"), "+1234"),
+            (StrProxy("+1234"), "+1234"),
+            (StrProxy("79787458007"), "+79787458007"),
+            (StrProxy("+79787458007"), "+79787458007"),
+        ]
+
+        ctx = ResolveContext(
+            record={},
+            property_values=[],
+            entity=None,
+            statements_meta={},
+            variables={},
+        )
+
+        for input_val, expected_result in param_list:
+            with self.subTest():
+                ctx.property_values = [StrProxy(input_val)]
+
+                actual_result = _resolve_transformer({"name": "thebeast.contrib.transformers.normalize_phone"}, ctx)[0]
+                self.assertEqual(actual_result, expected_result)
+                self.assertEqual(actual_result._meta.transformation, "thebeast.contrib.transformers.normalize_phone()")
+
     def test_decode_html_entities(self):
         param_list = [
             (StrProxy("foobar"), "foobar"),


### PR DESCRIPTION
FtM expects `phone` property to start with a plus sign, so a string without one will be dropped. 

This is especially frustrating when phones are fetched from list-typed source, as jmespath lacks ability to foreach/map values (or I haven't found one?):

```json
{"phones": ["1234","5678"]}
```

```yaml
# this will yield no values, and there's no convinient way to fix it
phone:
  column: phones
```

Either way, I was hoping it will be ok to use a transformer for this. 