### PR TITLE
Unfucking tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ followthemoney~=3.7.0
 jmespath
 PyYAML==6.0.2
 smart-open==7.0.5
-ijson==3.2.0.post0
+ijson==3.3.0
 pytest
 pytest-subtests
 fastjsonschema==2.15.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-followthemoney
+followthemoney~=3.7.0
 jmespath
 PyYAML==6.0
 smart-open==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 followthemoney~=3.7.0
 jmespath
-PyYAML==6.0
-smart-open==6.0.0
+PyYAML==6.0.2
+smart-open==7.0.5
 ijson==3.2.0.post0
 pytest
 pytest-subtests

--- a/thebeast/contrib/transformers/__init__.py
+++ b/thebeast/contrib/transformers/__init__.py
@@ -69,7 +69,14 @@ def anydatetime_parser(values: List[StrProxy], **kwargs) -> List[StrProxy]:
 
 def from_unixtime(values: List[StrProxy], silent=False, skip_zero_date=True) -> List[StrProxy]:
     """
-    Trying to create datetime from unix timestamp
+    Trying to create datetime from unix timestamp (utc)
+
+    Args:
+        values: list of unix timestamps as strings
+        silent: if True, will not raise exceptions and just skip the value
+        skip_zero_date: if True, will skip 0 unix timestamps
+    Returns:
+        list of datetime objects
     """
 
     res = []
@@ -79,7 +86,11 @@ def from_unixtime(values: List[StrProxy], silent=False, skip_zero_date=True) -> 
             if skip_zero_date and int(value) == 0:
                 continue
 
-            res.append(value.inject_meta_to_str(datetime.datetime.fromtimestamp(int(value))))
+            # This one was implemented incorrectly and was giving different naive datetimes
+            # according to the timezone of the machine it was run on.
+            # To keep the same behavior, we need to replace the timezone with UTC and
+            # then remove tzinfo.
+            res.append(value.inject_meta_to_str(datetime.datetime.fromtimestamp(int(value), tz=datetime.timezone.utc).replace(tzinfo=None)))
         except Exception:
             if silent:
                 pass


### PR DESCRIPTION
Fixing fromtimestamp tests so they assume utc. Upgrading to the fresh followthemoney. Aligning tests on RiggedEntityProxy with upstream implementation